### PR TITLE
Updated supported versions of numpy, pydantic, tables

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,16 +15,16 @@ The `cesnet-datazoo` package requires Python >=3.10.
 
 ### Dependencies
 
-| Name         | Version         |
-|--------------|-----------------|
-| matplotlib   |                 |
-| numpy        | <2.0            |
-| pandas       |                 |
-| pydantic     | >=2.0           |
-| PyYAML       |                 |
-| requests     |                 |
-| scikit-learn |                 |
-| seaborn      |                 |
-| tables       | >=3.8.0,<=3.9.2 |
-| torch        | >=1.10          |
-| tqdm         |                 |
+| Name         | Version                            |
+|--------------|------------------------------------|
+| matplotlib   |                                    |
+| numpy        |                                    |
+| pandas       |                                    |
+| pydantic     | >=2.0, !=2.9.*, !=2.10.*, <2.12.0  |
+| PyYAML       |                                    |
+| requests     |                                    |
+| scikit-learn |                                    |
+| seaborn      |                                    |
+| tables       | >=3.10.0                           |
+| torch        | >=1.10                             |
+| tqdm         |                                    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,14 @@ requires-python = ">=3.10"
 dependencies = [
   "cesnet_models",
   "matplotlib",
-  "numpy<2.0",
+  "numpy",
   "pandas",
-  "pydantic>=2.0,<=2.8.2",
+  "pydantic >=2.0, !=2.9.*, !=2.10.*, <2.12.0",
   "PyYAML",
   "requests",
   "scikit-learn",
   "seaborn",
-  "tables>=3.8.0,<=3.9.2",
+  "tables >=3.10.0",
   "torch>=1.10",
   "tqdm",
 ]


### PR DESCRIPTION
With tables version 3.10.0 or later, newer versions of numpy can be used. 
Pydantic versions 2.11.* are compatible, because they do not have the same issues as versions 2.9.* and 2.10.*.