### PR TITLE
Updated supported versions of pydantic

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ The `cesnet-datazoo` package requires Python >=3.10.
 | matplotlib   |                                    |
 | numpy        |                                    |
 | pandas       |                                    |
-| pydantic     | >=2.0, !=2.9.*, !=2.10.*, <2.12.0  |
+| pydantic     | >=2.0, !=2.9.*, <2.12.0            |
 | PyYAML       |                                    |
 | requests     |                                    |
 | scikit-learn |                                    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "matplotlib",
   "numpy",
   "pandas",
-  "pydantic >=2.0, !=2.9.*, !=2.10.*, <2.12.0",
+  "pydantic >=2.0, !=2.9.*, <2.12.0",
   "PyYAML",
   "requests",
   "scikit-learn",


### PR DESCRIPTION
Excluding Pydantic versions 2.10.* is unnecessary, as they do not cause the same issues as versions 2.9.*.